### PR TITLE
fix og:url en production

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -12,7 +12,16 @@ export const viewport: Viewport = {
   themeColor: "#2ecc71",
 };
 
-const siteUrl = process.env.NEXT_PUBLIC_SITE_URL || "http://localhost:3000";
+/**
+ * En production sur Vercel, VERCEL_PROJECT_PRODUCTION_URL (domaine stable du
+ * projet) est fourni automatiquement, sans configuration manuelle nécessaire.
+ */
+const siteUrl =
+  process.env.NEXT_PUBLIC_SITE_URL ||
+  (process.env.VERCEL_PROJECT_PRODUCTION_URL &&
+    `https://${process.env.VERCEL_PROJECT_PRODUCTION_URL}`) ||
+  (process.env.VERCEL_URL && `https://${process.env.VERCEL_URL}`) ||
+  "http://localhost:3000";
 const title = "L'Isle aux énigmes";
 const description =
   "Chasse au trésor géolocalisée autour du lac de L'Isle-Jourdain";


### PR DESCRIPTION
Closes #35

## Résumé
`og:url` et `og:image` pointaient vers `http://localhost:3000` en production (vérifié sur https://l-isle-aux-enigmes.vercel.app après le merge de la PR #34), car `NEXT_PUBLIC_SITE_URL` n'est pas configurée sur Vercel.

`layout.tsx` utilise maintenant `VERCEL_PROJECT_PRODUCTION_URL`, fournie automatiquement par Vercel à chaque build, en fallback avant `VERCEL_URL` puis `localhost` (dev local).

## Test plan
- [x] `npx tsc --noEmit` sans erreur
- [x] Build simulé avec `VERCEL_PROJECT_PRODUCTION_URL=l-isle-aux-enigmes.vercel.app npm run build` → `og:url` généré correctement dans le HTML statique