### PR TITLE
robustesse offline, nettoyage code et accessibilité

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,36 +1,105 @@
-This is a [Next.js](https://nextjs.org) project bootstrapped with [`create-next-app`](https://nextjs.org/docs/app/api-reference/cli/create-next-app).
+# L'Isle aux Énigmes
 
-## Getting Started
+PWA de chasses au trésor géolocalisées à L'Isle-Jourdain (Gers). Chaque
+aventure ("parcours") guide le joueur d'étape en étape via GPS ; à chaque
+étape, une énigme se débloque une fois dans la zone de validation.
 
-First, run the development server:
+Stack : Next.js (App Router) · TypeScript · Tailwind CSS · Leaflet /
+react-leaflet · next-pwa.
+
+## Démarrer
 
 ```bash
-npm run dev
-# or
-yarn dev
-# or
-pnpm dev
-# or
-bun dev
+npm install
+npm run dev      # serveur de dev sur http://localhost:3000
+npm run build    # build de production
+npm run lint     # ESLint
 ```
 
-Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.
+## Ajouter un parcours
 
-You can start editing the page by modifying `app/page.tsx`. The page auto-updates as you edit the file.
+Un parcours est un fichier JSON dans `public/`, chargé au runtime via
+`/chasse?parcours=<nom-du-fichier-sans-extension>`. Il doit respecter le
+schéma `Parcours` défini dans `src/lib/types.ts` :
 
-This project uses [`next/font`](https://nextjs.org/docs/app/building-your-application/optimizing/fonts) to automatically optimize and load [Geist](https://vercel.com/font), a new font family for Vercel.
+```jsonc
+{
+  "id": "islo-mon-parcours-001",
+  "version": "1.0",
+  "titre": "Titre affiché",
+  "description": "...",
+  "ville": "L'Isle-Jourdain",
+  "difficulty": 1,
+  "age_conseille": "6-9 ans",     // optionnel
+  "temps_estime": "30 min",       // optionnel
+  "config": {
+    "unite_distance": "metres",
+    "precision_gps_requise": 20,
+    "theme_color": "#2ecc71"
+  },
+  "point_depart": {                // optionnel : affiche un écran d'intro avant l'étape 1
+    "nom": "...",
+    "coords": { "lat": 0, "lng": 0 },
+    "texte_bienvenue": "...",
+    "consigne_action": "..."
+  },
+  "etapes": [
+    {
+      "id": "etape-1",
+      "nom": "...",
+      "instruction": "...",
+      "coords": { "lat": 0, "lng": 0 },
+      "validation_radius": 20,     // en mètres
+      "histoire": "...",
+      "enigme": {
+        "type": "TEXT",           // "TEXT" | "NUMBER" | "CHOICE"
+        "question": "...",
+        "reponse": "<hash>",      // voir ci-dessous — jamais en clair
+        "indice": "...",
+        "message_succes": "...",
+        "options": ["...", "..."] // uniquement pour type: "CHOICE"
+      }
+    }
+  ],
+  "final": {
+    "titre": "...",
+    "message": "...",
+    "code_validation": "MON-CODE-2026",
+    "recompense": "..."           // optionnel
+  }
+}
+```
 
-## Learn More
+### Réponses hachées
 
-To learn more about Next.js, take a look at the following resources:
+Le champ `enigme.reponse` ne doit **jamais** contenir la réponse en clair :
+n'importe qui peut ouvrir `/mon-parcours.json` directement dans le
+navigateur, ce qui révélerait toutes les solutions. Il doit contenir le hash
+SHA-256 de la réponse normalisée (minuscules, sans accents, espaces
+retirés — voir `src/lib/hash.ts`).
 
-- [Next.js Documentation](https://nextjs.org/docs) - learn about Next.js features and API.
-- [Learn Next.js](https://nextjs.org/learn) - an interactive Next.js tutorial.
+Pour générer un hash :
 
-You can check out [the Next.js GitHub repository](https://github.com/vercel/next.js) - your feedback and contributions are welcome!
+```bash
+npm run hash -- "Ma Réponse"
+```
 
-## Deploy on Vercel
+Une énigme peut accepter plusieurs formulations : dans ce cas `reponse` est
+un tableau de hashs (`["hash1", "hash2"]`).
 
-The easiest way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme) from the creators of Next.js.
+### Brancher le parcours dans l'app
 
-Check out our [Next.js deployment documentation](https://nextjs.org/docs/app/building-your-application/deploying) for more details.
+1. Ajouter une entrée dans `ADVENTURES` (`src/app/page.tsx`) pour qu'il
+   apparaisse sur la page d'accueil.
+2. Si le parcours a un thème visuel dédié (couleurs, photo de fond), l'ajouter
+   dans `src/lib/themes.ts` (`getTheme()` et, si besoin, `PARCOURS_PHOTOS`).
+
+## Structure du projet
+
+```
+src/app/            pages Next.js (accueil, /chasse)
+src/components/      composants UI (carte, formulaire d'énigme, écrans intro/fin...)
+src/hooks/           géolocalisation, progression (localStorage)
+src/lib/             types, thèmes, calcul de distance, hash des réponses
+public/*.json        les parcours (contenu du jeu)
+```

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,9 +1,13 @@
 import type { NextConfig } from "next";
 
 // eslint-disable-next-line @typescript-eslint/no-require-imports
+const runtimeCaching = require("next-pwa/cache");
+
+// eslint-disable-next-line @typescript-eslint/no-require-imports
 const withPWA = require("next-pwa")({
   dest: "public",
   disable: process.env.NODE_ENV === "development",
+  runtimeCaching,
 });
 
 const nextConfig: NextConfig = {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "dev": "next dev",
     "build": "next build --webpack",
     "start": "next start",
-    "lint": "eslint"
+    "lint": "eslint",
+    "hash": "node scripts/hash-answer.js"
   },
   "dependencies": {
     "@types/leaflet": "^1.9.21",

--- a/scripts/hash-answer.js
+++ b/scripts/hash-answer.js
@@ -1,0 +1,22 @@
+#!/usr/bin/env node
+// Génère le hash SHA-256 à mettre dans le champ "reponse" d'un JSON de parcours.
+// Usage : npm run hash -- "Ma Réponse"
+
+const crypto = require("crypto");
+
+function normalize(s) {
+  return s
+    .trim()
+    .toLowerCase()
+    .normalize("NFD")
+    .replace(/[̀-ͯ]/g, "");
+}
+
+const answer = process.argv[2];
+if (!answer) {
+  console.error('Usage: npm run hash -- "Ma Réponse"');
+  process.exit(1);
+}
+
+const hash = crypto.createHash("sha256").update(normalize(answer)).digest("hex");
+console.log(hash);

--- a/src/app/chasse/page.tsx
+++ b/src/app/chasse/page.tsx
@@ -5,7 +5,7 @@ import { useSearchParams } from "next/navigation";
 import dynamic from "next/dynamic";
 import Link from "next/link";
 import { Parcours } from "@/lib/types";
-import { getTheme } from "@/lib/themes";
+import { getTheme, getParcoursPhoto } from "@/lib/themes";
 import { ThemeProvider } from "@/lib/ThemeContext";
 import { useGeolocation } from "@/hooks/useGeolocation";
 import { useProgression } from "@/hooks/useProgression";
@@ -23,8 +23,13 @@ function ChasseContent() {
 
   const [parcours, setParcours] = useState<Parcours | null>(null);
   const [loadError, setLoadError] = useState(false);
-  const [introDismissed, setIntroDismissed] = useState(false);
+  const [dismissedManually, setDismissedManually] = useState(false);
   const { position, error: geoError } = useGeolocation();
+
+  const introSeenKey = `islo-intro-seen-${parcoursFile}`;
+  const introDismissed =
+    dismissedManually ||
+    (typeof window !== "undefined" && sessionStorage.getItem(introSeenKey) === "1");
 
   const totalSteps = parcours?.etapes.length ?? 0;
   const storageKey = `islo-progression-${parcoursFile}`;
@@ -40,14 +45,6 @@ function ChasseContent() {
       .then((d: Parcours) => setParcours(d))
       .catch(() => setLoadError(true));
   }, [parcoursFile]);
-
-  useEffect(() => {
-    const key = `islo-intro-seen-${parcoursFile}`;
-    if (sessionStorage.getItem(key)) {
-      setIntroDismissed(true);
-    }
-  }, [parcoursFile]);
-
 
   if (loadError) {
     return (
@@ -85,8 +82,8 @@ function ChasseContent() {
         <IntroScreen
           parcours={parcours}
           onStart={() => {
-            sessionStorage.setItem(`islo-intro-seen-${parcoursFile}`, "1");
-            setIntroDismissed(true);
+            sessionStorage.setItem(introSeenKey, "1");
+            setDismissedManually(true);
           }}
         />
       </ThemeProvider>
@@ -103,20 +100,9 @@ function ChasseContent() {
 
   const currentEtape = parcours.etapes[currentStepIndex];
 
-  const photoMap: Record<string, string> = {
-    "islo-hist-710-001": "/icons/livres.jpg",
-    "islo-kids-lac-001": "/icons/fée.jpg",
-    "islo-spy-007":      "/icons/top_secret.jpg",
-    "islo-hist-002":     "/icons/campanaire.jpg",
-  };
-  const overlayMap: Record<string, string> = {
-    "islo-hist-710-001": "rgba(120, 80, 20, 0.80)",
-    "islo-kids-lac-001": "rgba(140, 50, 140, 0.78)",
-    "islo-spy-007":      "rgba(5, 20, 5, 0.82)",
-    "islo-hist-002":     "rgba(120, 80, 20, 0.80)",
-  };
-  const photo = photoMap[parcours.id];
-  const overlay = overlayMap[parcours.id];
+  const parcoursPhoto = getParcoursPhoto(parcours.id);
+  const photo = parcoursPhoto?.photo;
+  const overlay = parcoursPhoto?.overlayGame;
 
   return (
     <ThemeProvider theme={theme}>
@@ -132,7 +118,7 @@ function ChasseContent() {
         {/* Title bar */}
         <div className={`relative z-10 shrink-0 px-4 pt-3 pb-2 flex items-center gap-3 backdrop-blur-sm`}
           style={{ background: "rgba(0,0,0,0.25)" }}>
-          <Link href="/" className={`${theme.backColor} active:opacity-70 transition-opacity`}>
+          <Link href="/" aria-label="Retour à l'accueil" className={`${theme.backColor} active:opacity-70 transition-opacity`}>
             <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" className="w-5 h-5">
               <path fillRule="evenodd" d="M17 10a.75.75 0 01-.75.75H5.612l4.158 3.96a.75.75 0 11-1.04 1.08l-5.5-5.25a.75.75 0 010-1.08l5.5-5.25a.75.75 0 111.04 1.08L5.612 9.25H16.25A.75.75 0 0117 10z" clipRule="evenodd" />
             </svg>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -263,17 +263,6 @@ function Compass({ heading, targetBearing, targetEmoji }: {
   );
 }
 
-/* ── DifficultyStars ────────────────────────────────── */
-function DifficultyStars({ value, color }: { value: number; color: string }) {
-  return (
-    <span className="flex gap-0.5">
-      {[1, 2, 3].map((i) => (
-        <span key={i} className="text-sm" style={{ color: i <= value ? color : "rgba(0,0,0,0.15)" }}>★</span>
-      ))}
-    </span>
-  );
-}
-
 /* ── Illustrations SVG par thème ───────────────────── */
 function IllustrationHistoire({ filter }: { filter: string }) {
   return (
@@ -569,6 +558,7 @@ function MissionCard({ data, meta, progress, distM, alwaysAccessible = false }: 
 /* ── Page ───────────────────────────────────────────── */
 export default function Home() {
   const [adventures, setAdventures] = useState<(AdventureInfo | null)[]>(ADVENTURES.map(() => null));
+  const [loadErrors, setLoadErrors] = useState<boolean[]>(ADVENTURES.map(() => false));
   const [progresses, setProgresses] = useState<number[]>(ADVENTURES.map(() => 0));
   const [userPos, setUserPos] = useState<{ lat: number; lng: number } | null>(null);
   const [geoStatus, setGeoStatus] = useState<"idle" | "loading" | "ok" | "denied">("idle");
@@ -583,9 +573,15 @@ export default function Home() {
   useEffect(() => {
     ADVENTURES.forEach((meta, i) => {
       fetch(`/${meta.file}.json`)
-        .then((r) => r.json())
+        .then((r) => {
+          if (!r.ok) throw new Error(`HTTP ${r.status}`);
+          return r.json();
+        })
         .then((d: AdventureInfo) =>
           setAdventures((prev) => { const n = [...prev]; n[i] = d; return n; })
+        )
+        .catch(() =>
+          setLoadErrors((prev) => { const n = [...prev]; n[i] = true; return n; })
         );
       try {
         const raw = localStorage.getItem(`islo-progression-${meta.file}`);
@@ -906,6 +902,14 @@ const cardWidth = (el.scrollWidth - padding * 2) / ADVENTURES.length;
             }}>
             {ADVENTURES.map((meta, i) => {
               const data = adventures[i];
+              if (loadErrors[i]) return (
+                <div key={meta.file} className="shrink-0 snap-center w-[80vw] max-w-sm h-64 rounded-3xl flex items-center justify-center text-center px-6"
+                  style={{ background: "rgba(196,74,58,0.15)" }}>
+                  <p className="text-xs font-semibold" style={{ color: "#C44A3A" }}>
+                    ⚠️ Impossible de charger cette aventure. Vérifie ta connexion.
+                  </p>
+                </div>
+              );
               if (!data) return (
                 <div key={meta.file} className="shrink-0 snap-center w-[80vw] max-w-sm h-64 rounded-3xl animate-pulse" style={{ background: "rgba(196,74,58,0.15)" }} />
               );

--- a/src/components/FinalScreen.tsx
+++ b/src/components/FinalScreen.tsx
@@ -20,6 +20,12 @@ function useConfetti(canvasRef: React.RefObject<HTMLCanvasElement | null>, color
     canvas.width = window.innerWidth;
     canvas.height = window.innerHeight;
 
+    function handleResize() {
+      canvas!.width = window.innerWidth;
+      canvas!.height = window.innerHeight;
+    }
+    window.addEventListener("resize", handleResize);
+
     const particles = Array.from({ length: 120 }, () => ({
       x: Math.random() * canvas.width,
       y: Math.random() * canvas.height - canvas.height,
@@ -54,7 +60,10 @@ function useConfetti(canvasRef: React.RefObject<HTMLCanvasElement | null>, color
     }
     draw();
 
-    return () => cancelAnimationFrame(raf);
+    return () => {
+      cancelAnimationFrame(raf);
+      window.removeEventListener("resize", handleResize);
+    };
   }, [canvasRef, colors]);
 }
 
@@ -79,7 +88,7 @@ export default function FinalScreen({ final, onReset }: FinalScreenProps) {
 
         {id === "spy" && (
           <p className="text-[#00ff41]/40 text-xs font-mono tracking-widest uppercase">
-            // mission_status: complete
+            {"// mission_status: complete"}
           </p>
         )}
 

--- a/src/components/IntroScreen.tsx
+++ b/src/components/IntroScreen.tsx
@@ -4,6 +4,7 @@ import { useEffect, useState } from "react";
 import Link from "next/link";
 import { Parcours } from "@/lib/types";
 import { useTheme } from "@/lib/ThemeContext";
+import { getParcoursPhoto } from "@/lib/themes";
 import { useGeolocation } from "@/hooks/useGeolocation";
 import { haversineDistance } from "@/lib/geo";
 
@@ -164,21 +165,9 @@ export default function IntroScreen({ parcours, onStart }: IntroScreenProps) {
     ? haversineDistance(position, targetCoords)
     : null;
 
-  const photoMap: Record<string, string> = {
-    "islo-hist-710-001": "/icons/livres.jpg",
-    "islo-kids-lac-001": "/icons/fée.jpg",
-    "islo-spy-007":      "/icons/top_secret.jpg",
-    "islo-hist-002":     "/icons/campanaire.jpg",
-  };
-  const photo = photoMap[parcours.id];
-
-  const overlayMap: Record<string, string> = {
-    "islo-hist-710-001": "rgba(120, 80, 20, 0.72)",
-    "islo-kids-lac-001": "rgba(160, 60, 160, 0.68)",
-    "islo-spy-007":      "rgba(5, 20, 5, 0.78)",
-    "islo-hist-002":     "rgba(120, 80, 20, 0.72)",
-  };
-  const overlay = overlayMap[parcours.id] ?? "rgba(0,0,0,0.65)";
+  const parcoursPhoto = getParcoursPhoto(parcours.id);
+  const photo = parcoursPhoto?.photo;
+  const overlay = parcoursPhoto?.overlayIntro ?? "rgba(0,0,0,0.65)";
 
   return (
     <div className={`min-h-dvh flex flex-col ${t.fontClass} relative`}>
@@ -193,7 +182,7 @@ export default function IntroScreen({ parcours, onStart }: IntroScreenProps) {
       {/* Header */}
       <div className="relative z-10 shrink-0 px-4 pt-3 pb-2 flex items-center gap-3 backdrop-blur-sm"
         style={{ background: "rgba(0,0,0,0.25)" }}>
-        <Link href="/" className="text-white/70 active:opacity-70 transition-opacity">
+        <Link href="/" aria-label="Retour à l'accueil" className="text-white/70 active:opacity-70 transition-opacity">
           <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" className="w-5 h-5">
             <path fillRule="evenodd" d="M17 10a.75.75 0 01-.75.75H5.612l4.158 3.96a.75.75 0 11-1.04 1.08l-5.5-5.25a.75.75 0 010-1.08l5.5-5.25a.75.75 0 111.04 1.08L5.612 9.25H16.25A.75.75 0 0117 10z" clipRule="evenodd" />
           </svg>

--- a/src/hooks/useProgression.ts
+++ b/src/hooks/useProgression.ts
@@ -15,26 +15,23 @@ interface UseProgressionReturn extends Progression {
 
 const INITIAL: Progression = { currentStepIndex: 0, completedSteps: [] };
 
+function readProgression(storageKey: string): Progression {
+  if (typeof window === "undefined") return INITIAL;
+  try {
+    const raw = localStorage.getItem(storageKey);
+    if (raw) return JSON.parse(raw);
+  } catch {
+    // ignore corrupted data
+  }
+  return INITIAL;
+}
+
 export function useProgression(
   totalSteps: number,
   storageKey = "islo-progression"
 ): UseProgressionReturn {
-  const [state, setState] = useState<Progression>(INITIAL);
-  const [isLoaded, setIsLoaded] = useState(false);
-
-  // Load from localStorage on mount
-  useEffect(() => {
-    try {
-      const raw = localStorage.getItem(storageKey);
-      if (raw) {
-        const parsed: Progression = JSON.parse(raw);
-        setState(parsed);
-      }
-    } catch {
-      // ignore corrupted data
-    }
-    setIsLoaded(true);
-  }, [storageKey]);
+  const [state, setState] = useState<Progression>(() => readProgression(storageKey));
+  const isLoaded = typeof window !== "undefined";
 
   // Persist to localStorage on change
   useEffect(() => {

--- a/src/lib/themes.ts
+++ b/src/lib/themes.ts
@@ -366,3 +366,41 @@ export function getTheme(parcoursId: string): Theme {
   if (parcoursId === "islo-kids-lac-001" || parcoursId === "islo-kids-alliance-001") return FAIRY_THEME;
   return DEFAULT_THEME;
 }
+
+/**
+ * Photo de fond + overlay par parcours (uniquement les parcours qui en ont une).
+ * overlayIntro est légèrement plus clair que overlayGame pour laisser voir la photo
+ * sur l'écran d'introduction, avant que le texte des énigmes ne demande plus de contraste.
+ */
+interface ParcoursPhoto {
+  photo: string;
+  overlayGame: string;
+  overlayIntro: string;
+}
+
+const PARCOURS_PHOTOS: Record<string, ParcoursPhoto> = {
+  "islo-hist-710-001": {
+    photo: "/icons/livres.jpg",
+    overlayGame: "rgba(120, 80, 20, 0.80)",
+    overlayIntro: "rgba(120, 80, 20, 0.72)",
+  },
+  "islo-kids-lac-001": {
+    photo: "/icons/fée.jpg",
+    overlayGame: "rgba(140, 50, 140, 0.78)",
+    overlayIntro: "rgba(160, 60, 160, 0.68)",
+  },
+  "islo-spy-007": {
+    photo: "/icons/top_secret.jpg",
+    overlayGame: "rgba(5, 20, 5, 0.82)",
+    overlayIntro: "rgba(5, 20, 5, 0.78)",
+  },
+  "islo-hist-002": {
+    photo: "/icons/campanaire.jpg",
+    overlayGame: "rgba(120, 80, 20, 0.80)",
+    overlayIntro: "rgba(120, 80, 20, 0.72)",
+  },
+};
+
+export function getParcoursPhoto(parcoursId: string): ParcoursPhoto | undefined {
+  return PARCOURS_PHOTOS[parcoursId];
+}


### PR DESCRIPTION
Closes #37

## Résumé
- **Critique** : branche le cache offline PWA — `next-pwa/cache` fournit une config `runtimeCaching` (JSON en NetworkFirst, ressources cross-origin dont les tuiles de carte en cache) qui n'était jamais utilisée dans `next.config.ts`. Sans ça, le jeu pouvait casser en cas de perte de réseau en extérieur.
- **Critique** : ajoute `.catch` sur le fetch des aventures de la page d'accueil (même bug que celui déjà corrigé sur `/chasse`, oublié ici).
- **Important** : centralise le mapping parcours → photo/overlay dans `themes.ts` (`getParcoursPhoto`), qui était dupliqué à l'identique dans `chasse/page.tsx` et `IntroScreen.tsx`.
- **Important** : documente le README (description du projet, schéma JSON `Parcours` attendu, script `npm run hash` pour générer le hash d'une réponse).
- **Nettoyage** : corrige les 4 erreurs/warning ESLint préexistants (`react-hooks/set-state-in-effect` x2 via des initializers paresseux, commentaire JSX mal placé, composant mort `DifficultyStars`).
- **Nettoyage** : `aria-label` sur les boutons/liens retour icon-only ; le canvas de confettis gère maintenant le redimensionnement/rotation d'écran.

## Test plan
- [x] `npx tsc --noEmit` sans erreur
- [x] `npx eslint src` → 0 problème (contre 4 avant)
- [x] `npm run build` réussi
- [x] Vérifié que `sw.js` généré contient bien les règles de cache JSON/cross-origin
- [x] Test en dev réel : accueil, parcours avec intro (`alliancedes3pays`), parcours sans intro (`mvp`), parcours inexistant → tous 200
- [x] `npm run hash -- "Save"` produit le même hash que celui déjà stocké dans `mvp.json`